### PR TITLE
issues/814 Fail2ban - Cannot set ban time

### DIFF
--- a/Firewall.class.php
+++ b/Firewall.class.php
@@ -226,7 +226,11 @@ class Firewall extends \FreePBX_Helpers implements \BMO {
 	}
 
 	public function get_networkmaps(){
-		return $this->getConfig("networkmaps");
+		$networkmaps  = $this->getConfig("networkmaps");
+		if($networkmaps == false) {
+			return [];
+		}
+		return $networkmaps;
 	}
 
 	public function backup() {}


### PR DESCRIPTION
	The issue was that 'networkmaps' was returning a boolean instead of an array.